### PR TITLE
Update examples url to gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ asyncio.run(main())
 ```
 
 See [the documentation](https://stac-utils.github.io/rustac-py) for details.
-In particular, our [examples](https://stac-utils.github.io/rustac-py/latest/examples/) demonstrate some of the more interesting features.
+In particular, our [examples](https://stac-utils.github.io/rustac-py/latest/generated/gallery/) demonstrate some of the more interesting features.
 
 ## CLI
 


### PR DESCRIPTION
Best I can tell something changed in the mkdocs config and this is the correct URL