### PR TITLE
refactor: simplify extension handling in duckdb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,5 @@ cython_debug/
 #.idea/
 .vscode/
 docs/generated
+
+tests/duckdb-extensions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2167,9 +2167,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72"
 
 [[package]]
 name = "libredox"
@@ -2670,7 +2670,7 @@ dependencies = [
 [[package]]
 name = "pgstac"
 version = "0.3.0"
-source = "git+https://github.com/stac-utils/rustac?branch=main#6c284a1999a3fdbadd5f311a9d2d450249b09758"
+source = "git+https://github.com/stac-utils/rustac?branch=main#8f24498fd3d227067dab8738e1a792e57b7d7024"
 dependencies = [
  "serde",
  "serde_json",
@@ -3000,9 +3000,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
+checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
 dependencies = [
  "bytes",
  "getrandom 0.3.2",
@@ -3375,7 +3375,7 @@ dependencies = [
 [[package]]
 name = "rustac"
 version = "0.5.3"
-source = "git+https://github.com/stac-utils/rustac?branch=main#6c284a1999a3fdbadd5f311a9d2d450249b09758"
+source = "git+https://github.com/stac-utils/rustac?branch=main#8f24498fd3d227067dab8738e1a792e57b7d7024"
 dependencies = [
  "anyhow",
  "axum",
@@ -3777,7 +3777,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "stac"
 version = "0.12.0"
-source = "git+https://github.com/stac-utils/rustac?branch=main#6c284a1999a3fdbadd5f311a9d2d450249b09758"
+source = "git+https://github.com/stac-utils/rustac?branch=main#8f24498fd3d227067dab8738e1a792e57b7d7024"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "stac-api"
 version = "0.7.1"
-source = "git+https://github.com/stac-utils/rustac?branch=main#6c284a1999a3fdbadd5f311a9d2d450249b09758"
+source = "git+https://github.com/stac-utils/rustac?branch=main#8f24498fd3d227067dab8738e1a792e57b7d7024"
 dependencies = [
  "async-stream",
  "chrono",
@@ -3837,7 +3837,7 @@ dependencies = [
 [[package]]
 name = "stac-derive"
 version = "0.2.0"
-source = "git+https://github.com/stac-utils/rustac?branch=main#6c284a1999a3fdbadd5f311a9d2d450249b09758"
+source = "git+https://github.com/stac-utils/rustac?branch=main#8f24498fd3d227067dab8738e1a792e57b7d7024"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "stac-duckdb"
 version = "0.1.1"
-source = "git+https://github.com/stac-utils/rustac?branch=main#6c284a1999a3fdbadd5f311a9d2d450249b09758"
+source = "git+https://github.com/stac-utils/rustac?branch=main#8f24498fd3d227067dab8738e1a792e57b7d7024"
 dependencies = [
  "arrow-array",
  "chrono",
@@ -3865,7 +3865,7 @@ dependencies = [
 [[package]]
 name = "stac-server"
 version = "0.3.4"
-source = "git+https://github.com/stac-utils/rustac?branch=main#6c284a1999a3fdbadd5f311a9d2d450249b09758"
+source = "git+https://github.com/stac-utils/rustac?branch=main#8f24498fd3d227067dab8738e1a792e57b7d7024"
 dependencies = [
  "axum",
  "bb8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,6 +1018,7 @@ dependencies = [
  "memchr",
  "num-integer",
  "rust_decimal",
+ "serde_json",
  "smallvec",
  "strum",
 ]
@@ -3396,6 +3397,7 @@ version = "0.6.0"
 dependencies = [
  "cargo-lock",
  "clap",
+ "duckdb",
  "geoarrow-array",
  "geojson",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ duckdb-bundled = ["stac-duckdb/bundled"]
 
 [dependencies]
 clap = "4.5.31"
+duckdb = { version = "1.2.2", features = ["serde_json"] }
 geoarrow-array = { git = "https://github.com/geoarrow/geoarrow-rs/", rev = "17bf33e4cf78b060afa08ca9560dc4efd73c2c76" }
 geojson = "0.24.1"
 pyo3 = { version = "0.24.1", features = ["extension-module"] }

--- a/python/rustac/rustac.pyi
+++ b/python/rustac/rustac.pyi
@@ -1,5 +1,6 @@
 """The power of Rust for the Python STAC ecosystem."""
 
+from pathlib import Path
 from typing import Any, AsyncIterator, Literal, Optional, Tuple
 
 import arro3.core
@@ -15,28 +16,28 @@ class DuckdbClient:
     def __init__(
         self,
         *,
-        use_s3_credential_chain: bool = True,
-        use_azure_credential_chain: bool = True,
-        use_httpfs: bool = True,
+        extension_directory: Path | None = None,
+        extensions: list[str] | None = None,
+        install_spatial: bool = True,
         use_hive_partitioning: bool = False,
-        install_extensions: bool = True,
-        custom_extension_repository: str | None = None,
-        extension_directory: str | None = None,
     ) -> None:
         """Creates a new duckdb client.
 
         Args:
-            use_s3_credential_chain: If true, configures DuckDB to correctly
-                handle s3:// urls.
-            use_azure_credential_chain: If true, configures DuckDB to correctly
-                handle azure urls.
-            use_httpfs: If true, configures DuckDB to correctly handle https
-                urls.
-            use_hive_partitioning: If true, enables queries on hive partitioned
-                geoparquet files.
-            install_extensions: If true, installs extensions before loading them.
-            custom_extension_repository: A custom extension repository to use.
             extension_directory: A non-standard extension directory to use.
+            extensions: A list of extensions to LOAD on client initialization.
+            install_spatial: Whether to install the spatial extension on client initialization.
+            use_hive_partitioning: Whether to use hive partitioning for geoparquet queries.
+        """
+
+    def execute(self, sql: str, params: list[str] | None = None) -> int:
+        """Execute an SQL command.
+
+        This can be useful for configuring AWS credentials, for example.
+
+        Args:
+            sql: The SQL to execute
+            params: The parameters to pass in to the execution
         """
 
     def search(

--- a/scripts/test
+++ b/scripts/test
@@ -2,6 +2,5 @@
 
 set -e
 
-uv run maturin dev --uv -E arrow
 uv run pytest "$@"
 uv run rustac translate spec-examples/v1.1.0/simple-item.json /dev/null

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,9 @@ create_exception!(rustac, RustacError, PyException);
 #[derive(Debug, Error)]
 pub enum Error {
     #[error(transparent)]
+    Duckdb(#[from] duckdb::Error),
+
+    #[error(transparent)]
     Geojson(#[from] geojson::Error),
 
     #[error(transparent)]

--- a/tests/test_duckdb.py
+++ b/tests/test_duckdb.py
@@ -1,15 +1,19 @@
 from pathlib import Path
 
 import pytest
-from geopandas import GeoDataFrame
-
 import rustac
+from geopandas import GeoDataFrame
 from rustac import DuckdbClient, RustacError
 
 
 @pytest.fixture
 def client() -> DuckdbClient:
     return DuckdbClient()
+
+
+@pytest.fixture
+def extension_directory() -> Path:
+    return Path(__file__).parent / "duckdb-extensions"
 
 
 def test_search(client: DuckdbClient) -> None:
@@ -40,8 +44,7 @@ def test_search_to_arrow(client: DuckdbClient) -> None:
     assert len(item_collection["features"]) == 100
 
 
-def test_custom_extension_directory() -> None:
-    extension_directory = Path(__file__).parent / "duckdb-extensions"
+def test_custom_extension_directory(extension_directory: Path) -> None:
     client = DuckdbClient(extension_directory=extension_directory)
     # Search to ensure we trigger everything
     client.search("data/100-sentinel-2-items.parquet")
@@ -49,4 +52,29 @@ def test_custom_extension_directory() -> None:
 
 def test_no_install(tmp_path: Path) -> None:
     with pytest.raises(RustacError):
-        DuckdbClient(extension_directory=tmp_path, install_extensions=False)
+        DuckdbClient(extension_directory=tmp_path, install_spatial=False)
+
+
+def test_extensions(extension_directory: Path, tmp_path: Path) -> None:
+    # Ensure we've fetched the extension
+    DuckdbClient(extension_directory=extension_directory)
+
+    extension = next(extension_directory.glob("**/spatial.duckdb_extension"))
+    client = DuckdbClient(
+        extensions=[str(extension)], extension_directory=tmp_path, install_spatial=False
+    )
+    client.search("data/100-sentinel-2-items.parquet")
+
+
+def test_execute(client: DuckdbClient, extension_directory: Path) -> None:
+    # Just a smoke test
+    client.execute("SET extension_directory = ?", [str(extension_directory)])
+
+
+def test_load_spatial() -> None:
+    DuckdbClient(extensions=["spatial"])
+
+
+@pytest.mark.skip("slow")
+def test_aws_credential_chain(client: DuckdbClient) -> None:
+    client.execute("CREATE SECRET (TYPE S3, PROVIDER CREDENTIAL_CHAIN)")


### PR DESCRIPTION
cc @ceholden just FYSA since you helped work on this, I'm refactoring to Do Less™ here, but expose the ability to just execute any DuckDB query for custom setup, etc. I also provide a way to pass in extension files in init, which we can hopefully use to point to pre-fetched stuff in our lambda.