### PR TITLE
docs: fix missing stac page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,7 +34,6 @@ nav:
       - geoparquet: api/geoparquet.md
       - read: api/read.md
       - search: api/search.md
-      - stac: api/stac.md
       - store:
           - api/store/index.md
           - api/store/aws.md


### PR DESCRIPTION
I don't see the API for stac in the code so I guess it was removed some time ago 