### PR TITLE
feat: add fields argument for search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,11 +984,11 @@ dependencies = [
 
 [[package]]
 name = "cql2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2bd27e1adf331c4c1cc52ded883788d04bbf5d8c64842362da6397d5e93236"
+checksum = "563cecfd7f529013d5297a18eda58a1186fe95340058d7538fb7f421b16b6871"
 dependencies = [
- "geo 0.31.0",
+ "geo",
  "geo-types",
  "geojson 0.24.2",
  "geozero",
@@ -1251,12 +1251,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "earcutr"
-version = "0.4.3"
+name = "earcut"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79127ed59a85d7687c409e9978547cffb7dc79675355ed22da6b66fd5f6ead01"
+checksum = "88459a2a8e3a514b6e6de38cf3aaa9250a894cb098f74a932db77fcc8341b6d0"
 dependencies = [
- "itertools 0.11.0",
  "num-traits",
 ]
 
@@ -1337,9 +1336,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -1391,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "float_next_after"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
+checksum = "37007738a80ea34f969af54a3390dd72cacdef654974cfd449c9f6f72dbaac10"
 
 [[package]]
 name = "fluent-uri"
@@ -1599,36 +1598,19 @@ dependencies = [
 
 [[package]]
 name = "geo"
-version = "0.31.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc1a1678e54befc9b4bcab6cd43b8e7f834ae8ea121118b0fd8c42747675b4a"
+checksum = "30eb1fdc57c1e5cfd11826fe0caec4b9dc7901f3758263bb506228d88c8d9e9a"
 dependencies = [
- "earcutr",
+ "earcut",
  "float_next_after",
  "geo-types",
  "geographiclib-rs",
  "i_overlay",
  "log",
  "num-traits",
- "robust",
- "rstar 0.12.2",
- "spade",
-]
-
-[[package]]
-name = "geo"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3901269ec6d4f6068d3f09e5f02f995bd076398dcd1dfec407cd230b02d11b"
-dependencies = [
- "earcutr",
- "float_next_after",
- "geo-types",
- "geographiclib-rs",
- "i_overlay",
- "log",
- "num-traits",
- "rand 0.8.6",
+ "rand 0.10.1",
+ "rand_pcg",
  "robust",
  "rstar 0.12.2",
  "sif-itree",
@@ -1659,6 +1641,7 @@ dependencies = [
  "rstar 0.8.4",
  "rstar 0.9.3",
  "serde",
+ "spade",
 ]
 
 [[package]]
@@ -2090,24 +2073,27 @@ dependencies = [
 
 [[package]]
 name = "i_float"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010025c2c532c8d82e42d0b8bb5184afa449fa6f06c709ea9adcb16c49ae405b"
+checksum = "813145bb0ad5b60f55cbbf3c74cdceda1c0a9d253b35c4cc36ae0df7887cb78f"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "i_key_sort"
-version = "0.6.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9190f86706ca38ac8add223b2aed8b1330002b5cdbbce28fb58b10914d38fc27"
+checksum = "d73d122b937fca067feb0ad74f62388920272b27c356d4df2d0cfdd59e044cf0"
+dependencies = [
+ "rayon",
+]
 
 [[package]]
 name = "i_overlay"
-version = "4.0.7"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413183068e6e0289e18d7d0a1f661b81546e6918d5453a44570b9ab30cbed1b3"
+checksum = "8dd314b4668e2b3a12508f2e125558c82a6c0a8636fa5107a900f79ce414e450"
 dependencies = [
  "i_float",
  "i_key_sort",
@@ -2118,18 +2104,18 @@ dependencies = [
 
 [[package]]
 name = "i_shape"
-version = "1.14.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea154b742f7d43dae2897fcd5ead86bc7b5eefcedd305a7ebf9f69d44d61082"
+checksum = "bfa9eac533d7509a8ab87672b60ac610c17240f9ea4851d26227689fdfe349c8"
 dependencies = [
  "i_float",
 ]
 
 [[package]]
 name = "i_tree"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e6d558e6d4c7b82bc51d9c771e7a927862a161a7d87bf2b0541450e0e20915"
+checksum = "4804bdc1dc124eb7e1aa9e144ecc04096bcf787a10a15fa44af682b51f0f6cce"
 
 [[package]]
 name = "iana-time-zone"
@@ -2327,15 +2313,6 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2500,16 +2477,16 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.45.1"
+version = "0.46.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257eb0e588b76827bbddc9e73945a9743693dd2adeaee9da26420f93cfedb798"
+checksum = "6a5fe5206f06e589caf25e79fc05ccdf91fca745685fe9fe1a13bbdfb479a631"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
  "bytecount",
  "data-encoding",
  "email_address",
- "fancy-regex 0.17.0",
+ "fancy-regex 0.18.0",
  "fraction",
  "getrandom 0.3.4",
  "idna",
@@ -2517,7 +2494,7 @@ dependencies = [
  "num-cmp",
  "num-traits",
  "percent-encoding",
- "referencing 0.45.1",
+ "referencing 0.46.5",
  "regex",
  "regex-syntax",
  "reqwest 0.13.4",
@@ -2741,6 +2718,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,7 +2945,7 @@ dependencies = [
  "httparse",
  "humantime",
  "hyper",
- "itertools 0.14.0",
+ "itertools",
  "md-5 0.10.6",
  "parking_lot",
  "percent-encoding",
@@ -3545,7 +3528,7 @@ dependencies = [
  "futures",
  "http",
  "humantime",
- "itertools 0.14.0",
+ "itertools",
  "object_store",
  "percent-encoding",
  "pyo3",
@@ -3736,6 +3719,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3826,9 +3818,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.45.1"
+version = "0.46.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f38748ceca8d0b0013e60f534d94a6e23dfd89fd2a88318fc5a2d04fda1010"
+checksum = "69e4e17ef386c5383591d07623d3de49cbc601156e7582973e6db98d66a57de2"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -3836,6 +3828,8 @@ dependencies = [
  "futures",
  "getrandom 0.3.4",
  "hashbrown 0.16.1",
+ "itoa",
+ "micromap",
  "parking_lot",
  "percent-encoding",
  "serde_json",
@@ -4095,9 +4089,9 @@ dependencies = [
 
 [[package]]
 name = "rustac"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f8980fd4799c390d1333c5d0e99ac88a1d86bc99a20193a22ab92721c6788"
+checksum = "c856ae269da74768df7875fb69594e2f4bdfec1353e1fb1859010022d2ef8fde"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4643,9 +4637,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stac"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a069e4454aec3e4cf9340d2b2b242764086e23c452f1ff3deff29b30b2bf0b60"
+checksum = "5bf191f5a998a139913f92ae953d40b5f2276c3320c081ec09337619ed214104"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -4657,7 +4651,7 @@ dependencies = [
  "cql2",
  "futures",
  "futures-core",
- "geo 0.32.0",
+ "geo",
  "geo-traits",
  "geo-types",
  "geoarrow-array",
@@ -4690,9 +4684,9 @@ dependencies = [
 
 [[package]]
 name = "stac-duckdb"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0581b19784daf1cae918a94f7a57a57d6c35f806385466dad5230c6464a350ac"
+checksum = "de43c862e8743732de307763f242b3cedeeb65c770b84f0fce871c88a434598b"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -4701,7 +4695,7 @@ dependencies = [
  "duckdb",
  "futures",
  "futures-core",
- "geo 0.32.0",
+ "geo",
  "geoarrow-schema",
  "geojson 1.0.0",
  "getrandom 0.4.2",
@@ -4713,9 +4707,9 @@ dependencies = [
 
 [[package]]
 name = "stac-io"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3548fbaf7475c1f4c7227351f47508baacdd7cb2f0566dab9dcbab1e9239be9e"
+checksum = "7d2d1901ef3026361a399e44440d295c5e3edafae3c851a16a915d0cc41cb9f5"
 dependencies = [
  "async-stream",
  "bytes",
@@ -4735,9 +4729,9 @@ dependencies = [
 
 [[package]]
 name = "stac-server"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148771c13adb8fd195268b6450cf258af5ef989c2d88a4b6a7d0c0dd91d0b91d"
+checksum = "964117820bd14da110ca10e5c0fbbced02da0b335c5838f468bbe0b0a1352f86"
 dependencies = [
  "axum",
  "bb8",
@@ -4763,15 +4757,15 @@ dependencies = [
 
 [[package]]
 name = "stac-validate"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa71a81183c25ed4f427563239be055119bb2f5fe7fcb346019849b7e8142b24"
+checksum = "ee6984d6e39f05780cae52cc8e6b1d2f2df65f44d9a2437bd6d5c5b37524343e"
 dependencies = [
  "async-recursion",
  "async-trait",
  "fluent-uri 0.4.1",
- "jsonschema 0.45.1",
- "referencing 0.45.1",
+ "jsonschema 0.46.5",
+ "referencing 0.46.5",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -5123,13 +5117,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres-rustls"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27d684bad428a0f2481f42241f821db42c54e2dc81d8c00db8536c506b0a0144"
+checksum = "4c2ad44aa0ae96db89c4742212ed41645b2f597311ff6e1945542a4d9fadc2fb"
 dependencies = [
- "const-oid 0.9.6",
- "ring",
  "rustls",
+ "sha2 0.11.0",
  "tokio",
  "tokio-postgres",
  "tokio-rustls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,7 +394,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -416,7 +416,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -427,7 +427,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -647,7 +647,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -843,7 +843,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1124,7 +1124,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1135,7 +1135,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1164,7 +1164,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1184,7 +1184,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1217,14 +1217,14 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "duckdb"
-version = "1.10503.1"
+version = "1.10504.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb42b21e3be42ef14acda15ce8dc99c125ce5376b87c8016a432cf14ae65de1"
+checksum = "0b9b997383221efd999a362448a0866c54b9a2cb7d4da8cd4903ead4df9f8eaa"
 dependencies = [
  "arrow",
  "cast",
@@ -1537,7 +1537,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2372,7 +2372,7 @@ checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2417,7 +2417,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2436,7 +2436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2605,9 +2605,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.10503.1"
+version = "1.10504.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a4389c243e7afa0fbc8d8471031335ddc8a2dac4534f3290c9c2ba3edabab5"
+checksum = "94e67523a40ee3da30411e00e243990b3760d91877202ab2f39c03ab34f8dbfc"
 dependencies = [
  "cc",
  "flate2",
@@ -2896,7 +2896,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3017,7 +3017,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3170,7 +3170,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3256,7 +3256,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3375,7 +3375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3517,7 +3517,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3530,7 +3530,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3778,7 +3778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3807,7 +3807,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4402,7 +4402,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4480,7 +4480,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4632,7 +4632,7 @@ checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4685,7 +4685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "087057f442c3a980721f249f723db459460ce74221730c9b2115bd63957027ae"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4827,7 +4827,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4849,9 +4849,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4875,7 +4875,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4948,7 +4948,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4959,7 +4959,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5065,7 +5065,7 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5092,7 +5092,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5286,7 +5286,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5631,7 +5631,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -5713,18 +5713,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5794,7 +5794,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5805,7 +5805,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6059,7 +6059,7 @@ dependencies = [
  "heck",
  "indexmap 2.14.0",
  "prettyplease",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -6075,7 +6075,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -6210,7 +6210,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -6231,7 +6231,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6251,7 +6251,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -6272,7 +6272,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6305,7 +6305,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://stac-utils.github.io/rustac-py"
 repository = "https://github.com/stac-utils/rustac-py"
 
 [lib]
-name = "rustac"
+name = "rustac_python"
 crate-type = ["rlib", "cdylib"]
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ pythonize = "0.28.0"
 rustac = { version = "0.2.9", features = ["pgstac"] }
 serde = "1.0.217"
 serde_json = { version = "1.0.149", features = ["preserve_order"] }
-stac = { version = "0.17.0", features = ["geoarrow", "geoparquet"] }
+stac = { version = "0.17.1", features = ["geoarrow", "geoparquet"] }
 stac-duckdb = "0.3.7"
 stac-io = { version = "0.2.8", features = ["store-all", "geoparquet"] }
 thiserror = "2.0.18"

--- a/build.rs
+++ b/build.rs
@@ -2,11 +2,12 @@ use cargo_lock::Lockfile;
 
 fn main() {
     let lockfile = Lockfile::load("Cargo.lock").unwrap();
-    let package = lockfile
+    let sha = lockfile
         .packages
         .into_iter()
         .find(|package| package.name.as_str() == "rustac")
-        .unwrap();
-    let precise = package.source.unwrap().precise().unwrap().to_string();
-    println!("cargo:rustc-env=RUSTAC_SHA={}", precise);
+        .and_then(|package| package.source)
+        .and_then(|source| source.precise().map(ToString::to_string))
+        .unwrap_or_else(|| "local".to_string());
+    println!("cargo:rustc-env=RUSTAC_SHA={}", sha);
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ build-backend = "maturin"
 
 [tool.maturin]
 python-source = "python"
+module-name = "rustac.rustac"
 features = ["extension-module"]
 strip = true
 opt-level = "z"          # TODO compare with "s"

--- a/python/rustac/rustac.pyi
+++ b/python/rustac/rustac.pyi
@@ -118,7 +118,7 @@ class DuckdbClient:
         sortby: str | list[str | dict[str, str]] | None = None,
         filter: str | dict[str, Any] | None = None,
         query: dict[str, Any] | None = None,
-        fields: str | dict[str, Any] | None = None,
+        fields: str | list[str] | dict[str, Any] | None = None,
         **kwargs: str,
     ) -> list[dict[str, Any]]:
         """Search a stac-geoparquet file with duckdb, returning a list of items.
@@ -159,7 +159,9 @@ class DuckdbClient:
             fields: Fields to include in or exclude from the response,
                 per the [fields extension](https://github.com/stac-api-extensions/fields).
                 Strings are interpreted as a comma-delimited list (e.g.
-                `+properties.datetime,-geometry`); dictionaries as
+                `+properties.datetime,-geometry`); lists as the same
+                `+`/`-` prefixed field names (e.g.
+                `["properties.datetime", "-geometry"]`); dictionaries as
                 `{"include": [...], "exclude": [...]}`.
                 Any `include` or `exclude` arguments override the
                 corresponding values set here.
@@ -185,7 +187,7 @@ class DuckdbClient:
         sortby: str | list[str | dict[str, str]] | None = None,
         filter: str | dict[str, Any] | None = None,
         query: dict[str, Any] | None = None,
-        fields: str | dict[str, Any] | None = None,
+        fields: str | list[str] | dict[str, Any] | None = None,
         **kwargs: str,
     ) -> arro3.core.Table | None:
         """Search a stac-geoparquet file with duckdb, returning an arrow table
@@ -231,7 +233,9 @@ class DuckdbClient:
             fields: Fields to include in or exclude from the response,
                 per the [fields extension](https://github.com/stac-api-extensions/fields).
                 Strings are interpreted as a comma-delimited list (e.g.
-                `+properties.datetime,-geometry`); dictionaries as
+                `+properties.datetime,-geometry`); lists as the same
+                `+`/`-` prefixed field names (e.g.
+                `["properties.datetime", "-geometry"]`); dictionaries as
                 `{"include": [...], "exclude": [...]}`.
                 Any `include` or `exclude` arguments override the
                 corresponding values set here.
@@ -397,7 +401,7 @@ async def search(
     sortby: str | list[str | dict[str, str]] | None = None,
     filter: str | dict[str, Any] | None = None,
     query: dict[str, Any] | None = None,
-    fields: str | dict[str, Any] | None = None,
+    fields: str | list[str] | dict[str, Any] | None = None,
     headers: dict[str, str] | None = None,
     use_duckdb: bool | None = None,
     **kwargs: str,
@@ -445,7 +449,9 @@ async def search(
         fields: Fields to include in or exclude from the response,
             per the [fields extension](https://github.com/stac-api-extensions/fields).
             Strings are interpreted as a comma-delimited list (e.g.
-            `+properties.datetime,-geometry`); dictionaries as
+            `+properties.datetime,-geometry`); lists as the same
+            `+`/`-` prefixed field names (e.g.
+            `["properties.datetime", "-geometry"]`); dictionaries as
             `{"include": [...], "exclude": [...]}`.
             Any `include` or `exclude` arguments override the
             corresponding values set here.
@@ -483,7 +489,7 @@ def search_sync(
     sortby: str | list[str | dict[str, str]] | None = None,
     filter: str | dict[str, Any] | None = None,
     query: dict[str, Any] | None = None,
-    fields: str | dict[str, Any] | None = None,
+    fields: str | list[str] | dict[str, Any] | None = None,
     headers: dict[str, str] | None = None,
     use_duckdb: bool | None = None,
     **kwargs: str,
@@ -531,7 +537,9 @@ def search_sync(
         fields: Fields to include in or exclude from the response,
             per the [fields extension](https://github.com/stac-api-extensions/fields).
             Strings are interpreted as a comma-delimited list (e.g.
-            `+properties.datetime,-geometry`); dictionaries as
+            `+properties.datetime,-geometry`); lists as the same
+            `+`/`-` prefixed field names (e.g.
+            `["properties.datetime", "-geometry"]`); dictionaries as
             `{"include": [...], "exclude": [...]}`.
             Any `include` or `exclude` arguments override the
             corresponding values set here.
@@ -569,7 +577,7 @@ async def iter_search(
     sortby: str | list[str | dict[str, str]] | None = None,
     filter: str | dict[str, Any] | None = None,
     query: dict[str, Any] | None = None,
-    fields: str | dict[str, Any] | None = None,
+    fields: str | list[str] | dict[str, Any] | None = None,
     headers: dict[str, str] | None = None,
     **kwargs: str,
 ) -> AsyncIterator[dict[str, Any]]:
@@ -613,7 +621,9 @@ async def iter_search(
         fields: Fields to include in or exclude from the response,
             per the [fields extension](https://github.com/stac-api-extensions/fields).
             Strings are interpreted as a comma-delimited list (e.g.
-            `+properties.datetime,-geometry`); dictionaries as
+            `+properties.datetime,-geometry`); lists as the same
+            `+`/`-` prefixed field names (e.g.
+            `["properties.datetime", "-geometry"]`); dictionaries as
             `{"include": [...], "exclude": [...]}`.
             Any `include` or `exclude` arguments override the
             corresponding values set here.
@@ -651,7 +661,7 @@ async def search_to(
     sortby: str | list[str | dict[str, str]] | None = None,
     filter: str | dict[str, Any] | None = None,
     query: dict[str, Any] | None = None,
-    fields: str | dict[str, Any] | None = None,
+    fields: str | list[str] | dict[str, Any] | None = None,
     headers: dict[str, str] | None = None,
     format: str | None = None,
     parquet_compression: str | None = None,
@@ -703,7 +713,9 @@ async def search_to(
         fields: Fields to include in or exclude from the response,
             per the [fields extension](https://github.com/stac-api-extensions/fields).
             Strings are interpreted as a comma-delimited list (e.g.
-            `+properties.datetime,-geometry`); dictionaries as
+            `+properties.datetime,-geometry`); lists as the same
+            `+`/`-` prefixed field names (e.g.
+            `["properties.datetime", "-geometry"]`); dictionaries as
             `{"include": [...], "exclude": [...]}`.
             Any `include` or `exclude` arguments override the
             corresponding values set here.

--- a/python/rustac/rustac.pyi
+++ b/python/rustac/rustac.pyi
@@ -118,6 +118,7 @@ class DuckdbClient:
         sortby: str | list[str | dict[str, str]] | None = None,
         filter: str | dict[str, Any] | None = None,
         query: dict[str, Any] | None = None,
+        fields: str | dict[str, Any] | None = None,
         **kwargs: str,
     ) -> list[dict[str, Any]]:
         """Search a stac-geoparquet file with duckdb, returning a list of items.
@@ -155,6 +156,13 @@ class DuckdbClient:
                 cql2-text, dictionaries as cql2-json.
             query: Additional filtering based on properties.  It is recommended
                 to use filter instead, if possible.
+            fields: Fields to include in or exclude from the response,
+                per the [fields extension](https://github.com/stac-api-extensions/fields).
+                Strings are interpreted as a comma-delimited list (e.g.
+                `+properties.datetime,-geometry`); dictionaries as
+                `{"include": [...], "exclude": [...]}`.
+                Any `include` or `exclude` arguments override the
+                corresponding values set here.
             kwargs: Additional parameters to pass in to the search.
 
         Returns:
@@ -177,6 +185,7 @@ class DuckdbClient:
         sortby: str | list[str | dict[str, str]] | None = None,
         filter: str | dict[str, Any] | None = None,
         query: dict[str, Any] | None = None,
+        fields: str | dict[str, Any] | None = None,
         **kwargs: str,
     ) -> arro3.core.Table | None:
         """Search a stac-geoparquet file with duckdb, returning an arrow table
@@ -219,6 +228,13 @@ class DuckdbClient:
                 cql2-text, dictionaries as cql2-json.
             query: Additional filtering based on properties.  It is recommended
                 to use filter instead, if possible.
+            fields: Fields to include in or exclude from the response,
+                per the [fields extension](https://github.com/stac-api-extensions/fields).
+                Strings are interpreted as a comma-delimited list (e.g.
+                `+properties.datetime,-geometry`); dictionaries as
+                `{"include": [...], "exclude": [...]}`.
+                Any `include` or `exclude` arguments override the
+                corresponding values set here.
             kwargs: Additional parameters to pass in to the search.
 
         Returns:
@@ -381,6 +397,7 @@ async def search(
     sortby: str | list[str | dict[str, str]] | None = None,
     filter: str | dict[str, Any] | None = None,
     query: dict[str, Any] | None = None,
+    fields: str | dict[str, Any] | None = None,
     headers: dict[str, str] | None = None,
     use_duckdb: bool | None = None,
     **kwargs: str,
@@ -425,6 +442,13 @@ async def search(
             will be interpreted as cql2-text, dictionaries as cql2-json.
         query: Additional filtering based on properties.
             It is recommended to use filter instead, if possible.
+        fields: Fields to include in or exclude from the response,
+            per the [fields extension](https://github.com/stac-api-extensions/fields).
+            Strings are interpreted as a comma-delimited list (e.g.
+            `+properties.datetime,-geometry`); dictionaries as
+            `{"include": [...], "exclude": [...]}`.
+            Any `include` or `exclude` arguments override the
+            corresponding values set here.
         headers: Additional headers to include in requests to the STAC API.
         use_duckdb: Query with DuckDB. If None and the href has a
             'parquet' or 'geoparquet' extension, will be set to True. Defaults
@@ -459,6 +483,7 @@ def search_sync(
     sortby: str | list[str | dict[str, str]] | None = None,
     filter: str | dict[str, Any] | None = None,
     query: dict[str, Any] | None = None,
+    fields: str | dict[str, Any] | None = None,
     headers: dict[str, str] | None = None,
     use_duckdb: bool | None = None,
     **kwargs: str,
@@ -503,6 +528,13 @@ def search_sync(
             will be interpreted as cql2-text, dictionaries as cql2-json.
         query: Additional filtering based on properties.
             It is recommended to use filter instead, if possible.
+        fields: Fields to include in or exclude from the response,
+            per the [fields extension](https://github.com/stac-api-extensions/fields).
+            Strings are interpreted as a comma-delimited list (e.g.
+            `+properties.datetime,-geometry`); dictionaries as
+            `{"include": [...], "exclude": [...]}`.
+            Any `include` or `exclude` arguments override the
+            corresponding values set here.
         headers: Additional headers to include in requests to the STAC API.
         use_duckdb: Query with DuckDB. If None and the href has a
             'parquet' or 'geoparquet' extension, will be set to True. Defaults
@@ -537,6 +569,7 @@ async def iter_search(
     sortby: str | list[str | dict[str, str]] | None = None,
     filter: str | dict[str, Any] | None = None,
     query: dict[str, Any] | None = None,
+    fields: str | dict[str, Any] | None = None,
     headers: dict[str, str] | None = None,
     **kwargs: str,
 ) -> AsyncIterator[dict[str, Any]]:
@@ -577,6 +610,13 @@ async def iter_search(
             will be interpreted as cql2-text, dictionaries as cql2-json.
         query: Additional filtering based on properties.
             It is recommended to use filter instead, if possible.
+        fields: Fields to include in or exclude from the response,
+            per the [fields extension](https://github.com/stac-api-extensions/fields).
+            Strings are interpreted as a comma-delimited list (e.g.
+            `+properties.datetime,-geometry`); dictionaries as
+            `{"include": [...], "exclude": [...]}`.
+            Any `include` or `exclude` arguments override the
+            corresponding values set here.
         headers: Additional headers to include in requests to the STAC API.
         kwargs: Additional parameters to pass in to the search.
 
@@ -611,6 +651,7 @@ async def search_to(
     sortby: str | list[str | dict[str, str]] | None = None,
     filter: str | dict[str, Any] | None = None,
     query: dict[str, Any] | None = None,
+    fields: str | dict[str, Any] | None = None,
     headers: dict[str, str] | None = None,
     format: str | None = None,
     parquet_compression: str | None = None,
@@ -659,6 +700,13 @@ async def search_to(
             will be interpreted as cql2-text, dictionaries as cql2-json.
         query: Additional filtering based on properties.
             It is recommended to use filter instead, if possible.
+        fields: Fields to include in or exclude from the response,
+            per the [fields extension](https://github.com/stac-api-extensions/fields).
+            Strings are interpreted as a comma-delimited list (e.g.
+            `+properties.datetime,-geometry`); dictionaries as
+            `{"include": [...], "exclude": [...]}`.
+            Any `include` or `exclude` arguments override the
+            corresponding values set here.
         headers: Additional headers to include in requests to the STAC API.
         format: The output format. If none, will be inferred from
             the outfile extension, and if that fails will fall back to compact JSON.

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -1,6 +1,6 @@
 use crate::{
     Result,
-    search::{PySortby, StringOrDict, StringOrList},
+    search::{PySortby, StringOrDict, StringOrDictOrList, StringOrList},
 };
 use duckdb::Connection;
 use pyo3::{
@@ -98,7 +98,7 @@ impl DuckdbClient {
         sortby: Option<PySortby<'py>>,
         filter: Option<StringOrDict>,
         query: Option<Bound<'py, PyDict>>,
-        fields: Option<StringOrDict<'py>>,
+        fields: Option<StringOrDictOrList<'py>>,
         kwargs: Option<Bound<'py, PyDict>>,
     ) -> Result<Bound<'py, PyList>> {
         if max_items.is_some() {
@@ -150,7 +150,7 @@ impl DuckdbClient {
         sortby: Option<PySortby<'py>>,
         filter: Option<StringOrDict>,
         query: Option<Bound<'py, PyDict>>,
-        fields: Option<StringOrDict<'py>>,
+        fields: Option<StringOrDictOrList<'py>>,
         kwargs: Option<Bound<'py, PyDict>>,
     ) -> Result<Py<PyAny>> {
         let search = crate::search::build(

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -81,7 +81,7 @@ impl DuckdbClient {
         Ok(table.into_py_any(py)?)
     }
 
-    #[pyo3(signature = (href, *, intersects=None, ids=None, collections=None, limit=None, max_items=None, bbox=None, datetime=None, include=None, exclude=None, sortby=None, filter=None, query=None, **kwargs))]
+    #[pyo3(signature = (href, *, intersects=None, ids=None, collections=None, limit=None, max_items=None, bbox=None, datetime=None, include=None, exclude=None, sortby=None, filter=None, query=None, fields=None, **kwargs))]
     fn search<'py>(
         &self,
         py: Python<'py>,
@@ -98,6 +98,7 @@ impl DuckdbClient {
         sortby: Option<PySortby<'py>>,
         filter: Option<StringOrDict>,
         query: Option<Bound<'py, PyDict>>,
+        fields: Option<StringOrDict<'py>>,
         kwargs: Option<Bound<'py, PyDict>>,
     ) -> Result<Bound<'py, PyList>> {
         if max_items.is_some() {
@@ -118,6 +119,7 @@ impl DuckdbClient {
             sortby,
             filter,
             query,
+            fields,
             kwargs,
         )?;
         let item_collection = {
@@ -132,7 +134,7 @@ impl DuckdbClient {
         Ok(list)
     }
 
-    #[pyo3(signature = (href, *, intersects=None, ids=None, collections=None, limit=None, bbox=None, datetime=None, include=None, exclude=None, sortby=None, filter=None, query=None, **kwargs))]
+    #[pyo3(signature = (href, *, intersects=None, ids=None, collections=None, limit=None, bbox=None, datetime=None, include=None, exclude=None, sortby=None, filter=None, query=None, fields=None, **kwargs))]
     fn search_to_arrow<'py>(
         &self,
         py: Python<'py>,
@@ -148,6 +150,7 @@ impl DuckdbClient {
         sortby: Option<PySortby<'py>>,
         filter: Option<StringOrDict>,
         query: Option<Bound<'py, PyDict>>,
+        fields: Option<StringOrDict<'py>>,
         kwargs: Option<Bound<'py, PyDict>>,
     ) -> Result<Py<PyAny>> {
         let search = crate::search::build(
@@ -162,6 +165,7 @@ impl DuckdbClient {
             sortby,
             filter,
             query,
+            fields,
             kwargs,
         )?;
         let record_batches = {

--- a/src/search.rs
+++ b/src/search.rs
@@ -455,9 +455,9 @@ pub enum StringOrDict<'py> {
     Dict(Bound<'py, PyDict>),
 }
 
-/// A string or dictionary.
+/// A string, dictionary, or list.
 ///
-/// Used for the CQL2 filter argument and for intersects.
+/// Used for fields.
 #[derive(Debug, FromPyObject)]
 pub enum StringOrDictOrList<'py> {
     /// Text

--- a/src/search.rs
+++ b/src/search.rs
@@ -54,7 +54,7 @@ pub fn iter_search<'py>(
     sortby: Option<PySortby<'py>>,
     filter: Option<StringOrDict>,
     query: Option<Bound<'py, PyDict>>,
-    fields: Option<StringOrDict>,
+    fields: Option<StringOrDictOrList>,
     headers: Option<HashMap<String, String>>,
     kwargs: Option<Bound<'_, PyDict>>,
 ) -> PyResult<Bound<'py, PyAny>> {
@@ -98,7 +98,7 @@ pub fn search<'py>(
     sortby: Option<PySortby<'py>>,
     filter: Option<StringOrDict>,
     query: Option<Bound<'py, PyDict>>,
-    fields: Option<StringOrDict>,
+    fields: Option<StringOrDictOrList>,
     headers: Option<HashMap<String, String>>,
     use_duckdb: Option<bool>,
     kwargs: Option<Bound<'_, PyDict>>,
@@ -152,7 +152,7 @@ pub fn search_sync<'py>(
     sortby: Option<PySortby<'py>>,
     filter: Option<StringOrDict>,
     query: Option<Bound<'py, PyDict>>,
-    fields: Option<StringOrDict>,
+    fields: Option<StringOrDictOrList>,
     headers: Option<HashMap<String, String>>,
     use_duckdb: Option<bool>,
     kwargs: Option<Bound<'_, PyDict>>,
@@ -207,7 +207,7 @@ pub fn search_to<'py>(
     sortby: Option<PySortby<'py>>,
     filter: Option<StringOrDict>,
     query: Option<Bound<'py, PyDict>>,
-    fields: Option<StringOrDict>,
+    fields: Option<StringOrDictOrList>,
     headers: Option<HashMap<String, String>>,
     format: Option<String>,
     parquet_compression: Option<String>,
@@ -361,7 +361,7 @@ pub fn build<'py>(
     sortby: Option<PySortby<'py>>,
     filter: Option<StringOrDict<'py>>,
     query: Option<Bound<'py, PyDict>>,
-    fields: Option<StringOrDict<'py>>,
+    fields: Option<StringOrDictOrList<'py>>,
     kwargs: Option<Bound<'py, PyDict>>,
 ) -> PyResult<Search> {
     let mut fields = fields
@@ -455,6 +455,21 @@ pub enum StringOrDict<'py> {
     Dict(Bound<'py, PyDict>),
 }
 
+/// A string or dictionary.
+///
+/// Used for the CQL2 filter argument and for intersects.
+#[derive(Debug, FromPyObject)]
+pub enum StringOrDictOrList<'py> {
+    /// Text
+    String(String),
+
+    /// Json
+    Dict(Bound<'py, PyDict>),
+
+    /// A list.
+    List(Vec<String>),
+}
+
 /// A string or a list.
 ///
 /// Used for collections, ids, etc.
@@ -491,13 +506,16 @@ impl From<StringOrList> for Vec<String> {
     }
 }
 
-impl<'py> TryFrom<StringOrDict<'py>> for Fields {
+impl<'py> TryFrom<StringOrDictOrList<'py>> for Fields {
     type Error = Error;
-    fn try_from(value: StringOrDict) -> Result<Fields> {
+    fn try_from(value: StringOrDictOrList) -> Result<Fields> {
         match value {
-            StringOrDict::String(s) => Ok(s.parse().unwrap()),
-            StringOrDict::Dict(dict) => {
+            StringOrDictOrList::String(s) => Ok(s.parse().unwrap()),
+            StringOrDictOrList::Dict(dict) => {
                 pythonize::depythonize(&dict).map_err(|e| Error::Pythonize(e))
+            }
+            StringOrDictOrList::List(list) => {
+                serde_json::from_value(serde_json::json!(list)).map_err(Error::from)
             }
         }
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -38,7 +38,7 @@ impl SearchIterator {
 }
 
 #[pyfunction]
-#[pyo3(signature = (href, *, intersects=None, ids=None, collections=None, limit=None, bbox=None, datetime=None, include=None, exclude=None, sortby=None, filter=None, query=None, headers=None, **kwargs))]
+#[pyo3(signature = (href, *, intersects=None, ids=None, collections=None, limit=None, bbox=None, datetime=None, include=None, exclude=None, sortby=None, filter=None, query=None, fields=None, headers=None, **kwargs))]
 #[allow(clippy::too_many_arguments)]
 pub fn iter_search<'py>(
     py: Python<'py>,
@@ -54,6 +54,7 @@ pub fn iter_search<'py>(
     sortby: Option<PySortby<'py>>,
     filter: Option<StringOrDict>,
     query: Option<Bound<'py, PyDict>>,
+    fields: Option<StringOrDict>,
     headers: Option<HashMap<String, String>>,
     kwargs: Option<Bound<'_, PyDict>>,
 ) -> PyResult<Bound<'py, PyAny>> {
@@ -69,6 +70,7 @@ pub fn iter_search<'py>(
         sortby,
         filter,
         query,
+        fields,
         kwargs,
     )?;
     let headers = into_headers(headers);
@@ -79,7 +81,7 @@ pub fn iter_search<'py>(
 }
 
 #[pyfunction]
-#[pyo3(signature = (href, *, intersects=None, ids=None, collections=None, max_items=None, limit=None, bbox=None, datetime=None, include=None, exclude=None, sortby=None, filter=None, query=None, headers=None, use_duckdb=None, **kwargs))]
+#[pyo3(signature = (href, *, intersects=None, ids=None, collections=None, max_items=None, limit=None, bbox=None, datetime=None, include=None, exclude=None, sortby=None, filter=None, query=None, fields=None, headers=None, use_duckdb=None, **kwargs))]
 #[allow(clippy::too_many_arguments)]
 pub fn search<'py>(
     py: Python<'py>,
@@ -96,6 +98,7 @@ pub fn search<'py>(
     sortby: Option<PySortby<'py>>,
     filter: Option<StringOrDict>,
     query: Option<Bound<'py, PyDict>>,
+    fields: Option<StringOrDict>,
     headers: Option<HashMap<String, String>>,
     use_duckdb: Option<bool>,
     kwargs: Option<Bound<'_, PyDict>>,
@@ -112,6 +115,7 @@ pub fn search<'py>(
         sortby,
         filter,
         query,
+        fields,
         kwargs,
     )?;
     let headers = into_headers(headers);
@@ -131,7 +135,7 @@ pub fn search<'py>(
 }
 
 #[pyfunction]
-#[pyo3(signature = (href, *, intersects=None, ids=None, collections=None, max_items=None, limit=None, bbox=None, datetime=None, include=None, exclude=None, sortby=None, filter=None, query=None, headers=None, use_duckdb=None, **kwargs))]
+#[pyo3(signature = (href, *, intersects=None, ids=None, collections=None, max_items=None, limit=None, bbox=None, datetime=None, include=None, exclude=None, sortby=None, filter=None, query=None, fields=None, headers=None, use_duckdb=None, **kwargs))]
 #[allow(clippy::too_many_arguments)]
 pub fn search_sync<'py>(
     py: Python<'py>,
@@ -148,6 +152,7 @@ pub fn search_sync<'py>(
     sortby: Option<PySortby<'py>>,
     filter: Option<StringOrDict>,
     query: Option<Bound<'py, PyDict>>,
+    fields: Option<StringOrDict>,
     headers: Option<HashMap<String, String>>,
     use_duckdb: Option<bool>,
     kwargs: Option<Bound<'_, PyDict>>,
@@ -164,6 +169,7 @@ pub fn search_sync<'py>(
         sortby,
         filter,
         query,
+        fields,
         kwargs,
     )?;
     let headers = into_headers(headers);
@@ -183,7 +189,7 @@ pub fn search_sync<'py>(
 }
 
 #[pyfunction]
-#[pyo3(signature = (outfile, href, *, intersects=None, ids=None, collections=None, max_items=None, limit=None, bbox=None, datetime=None, include=None, exclude=None, sortby=None, filter=None, query=None, headers=None, format=None, parquet_compression=None, store=None, use_duckdb=None, **kwargs))]
+#[pyo3(signature = (outfile, href, *, intersects=None, ids=None, collections=None, max_items=None, limit=None, bbox=None, datetime=None, include=None, exclude=None, sortby=None, filter=None, query=None, fields=None, headers=None, format=None, parquet_compression=None, store=None, use_duckdb=None, **kwargs))]
 #[allow(clippy::too_many_arguments)]
 pub fn search_to<'py>(
     py: Python<'py>,
@@ -201,6 +207,7 @@ pub fn search_to<'py>(
     sortby: Option<PySortby<'py>>,
     filter: Option<StringOrDict>,
     query: Option<Bound<'py, PyDict>>,
+    fields: Option<StringOrDict>,
     headers: Option<HashMap<String, String>>,
     format: Option<String>,
     parquet_compression: Option<String>,
@@ -220,6 +227,7 @@ pub fn search_to<'py>(
         sortby,
         filter,
         query,
+        fields,
         kwargs,
     )?;
     let headers = into_headers(headers);
@@ -353,9 +361,13 @@ pub fn build<'py>(
     sortby: Option<PySortby<'py>>,
     filter: Option<StringOrDict<'py>>,
     query: Option<Bound<'py, PyDict>>,
+    fields: Option<StringOrDict<'py>>,
     kwargs: Option<Bound<'py, PyDict>>,
 ) -> PyResult<Search> {
-    let mut fields = Fields::default();
+    let mut fields = fields
+        .map(|fields| fields.try_into())
+        .transpose()?
+        .unwrap_or_else(Fields::default);
     if let Some(include) = include {
         fields.include = include.into();
     }
@@ -475,6 +487,18 @@ impl From<StringOrList> for Vec<String> {
         match value {
             StringOrList::List(list) => list,
             StringOrList::String(s) => vec![s],
+        }
+    }
+}
+
+impl<'py> TryFrom<StringOrDict<'py>> for Fields {
+    type Error = Error;
+    fn try_from(value: StringOrDict) -> Result<Fields> {
+        match value {
+            StringOrDict::String(s) => Ok(s.parse().unwrap()),
+            StringOrDict::Dict(dict) => {
+                pythonize::depythonize(&dict).map_err(|e| Error::Pythonize(e))
+            }
         }
     }
 }

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -179,3 +179,10 @@ async def test_search_to_headers(
         httpserver.url_for("/"),
         headers={"x-rustac-test": "search-to"},
     )
+
+
+async def test_search_fields(httpserver: HTTPServer) -> None:
+    httpserver.expect_request(
+        "/search", json={"fields": {"include": ["foo", "bar"], "exclude": ["baz"]}}
+    ).respond_with_json({"features": [], "links": []})
+    await rustac.search(httpserver.url_for("/"), fields="foo,bar,-baz")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -186,3 +186,10 @@ async def test_search_fields(httpserver: HTTPServer) -> None:
         "/search", json={"fields": {"include": ["foo", "bar"], "exclude": ["baz"]}}
     ).respond_with_json({"features": [], "links": []})
     await rustac.search(httpserver.url_for("/"), fields="foo,bar,-baz")
+
+
+async def test_search_fields_list(httpserver: HTTPServer) -> None:
+    httpserver.expect_request(
+        "/search", json={"fields": {"include": ["foo", "bar"], "exclude": ["baz"]}}
+    ).respond_with_json({"features": [], "links": []})
+    await rustac.search(httpserver.url_for("/"), fields=["foo", "bar", "-baz"])


### PR DESCRIPTION
We had include and exclude, but to keep in line with pystac-client we should have fields, too.

Closes #300 